### PR TITLE
Add 'comfy' theme that inherits ComfyUI design tokens

### DIFF
--- a/web/aimdo_viz.css
+++ b/web/aimdo_viz.css
@@ -126,6 +126,44 @@
     --aimdo-type-style_model: #f472b6; --aimdo-type-gligen: #a855f7; --aimdo-type-upscale_model: #3b82f6;
 }
 
+/* Inherits ComfyUI's design tokens via var() so the panel adopts whatever
+   palette the host is in (light/dark mode is read live through the cascade).
+   --aimdo-type-* and --aimdo-fadeOut* are intentionally omitted — the
+   LiteGraph slot hues and fade RGB triplets from :root carry through. */
+[data-aimdo-theme="comfy"] {
+    --aimdo-bg:         var(--comfy-menu-bg);
+    --aimdo-rowBg:      var(--comfy-menu-secondary-bg);
+    --aimdo-headerBg:   var(--comfy-menu-bg);
+    --aimdo-border:     var(--border-color);
+    --aimdo-btn:        var(--comfy-input-bg);
+    --aimdo-btnText:    var(--input-text);
+    --aimdo-text:       var(--input-text);
+    --aimdo-textDim:    var(--descrip-text);
+    --aimdo-running:    var(--input-text);
+    --aimdo-graphBg:    var(--comfy-menu-secondary-bg);
+    --aimdo-gridLine:   var(--border-color);
+    --aimdo-barBg:      var(--comfy-input-bg);
+    --aimdo-totalLine:  var(--fg-color);
+    --aimdo-capLine:    var(--border-color);
+
+    --aimdo-vram:       var(--color-gold-500);
+    --aimdo-torch:      var(--color-jade-600);
+    --aimdo-pinned:     var(--color-azure-400);
+    --aimdo-loadedRam:  var(--color-cobalt-800);
+    --aimdo-unloaded:   var(--color-ash-800);
+    --aimdo-torchCache: var(--color-jade-600);
+    --aimdo-python:     var(--color-magenta-700);
+    --aimdo-other:      var(--color-neutral-550);
+    --aimdo-gpuUtil:    var(--color-gold-500);
+    --aimdo-gpuUtilHi:  var(--color-coral-500);
+
+    /* Neutral fade endpoints chosen to read OK against both light and dark
+       Comfy backgrounds — the dark-tuned :root defaults would streak black
+       on light mode. */
+    --aimdo-fadeOutFrom: 200, 100, 80;
+    --aimdo-fadeOutTo:   128, 128, 128;
+}
+
 /* CUSTOM THEME: Lucifer - Black and Red */
 [data-aimdo-theme="lucifer"] {
     --aimdo-bg: #000000;

--- a/web/aimdo_viz.js
+++ b/web/aimdo_viz.js
@@ -46,7 +46,7 @@ function saveState(patch) {
 // <html> — CSS does the rest. JS keeps a parallel `C` palette object only
 // because <canvas> can't read CSS variables; canvas rendering reads hex/rgb
 // strings from C, which we refresh from computed CSS on each theme switch.
-const THEME_NAMES = ["default", "light", "sepia", "fallout", "pink", "lucifer"];
+const THEME_NAMES = ["default", "comfy", "light", "sepia", "fallout", "pink", "lucifer"];
 
 // Keys whose values are color strings the canvas can read directly. fadeOutFrom /
 // fadeOutTo are stored as comma-separated RGB triplets in CSS and parsed into
@@ -110,6 +110,18 @@ function applyPalette(name) {
         const rgb = v && parseRgbTriplet(v);
         if (rgb) C[k] = rgb;
     }
+}
+
+// The "comfy" theme maps --aimdo-* to ComfyUI's --comfy-*/--color-* tokens via
+// var(). Those tokens themselves change when ComfyUI toggles its .dark-theme
+// class on <html> or <body>. DOM elements track that automatically through
+// the cascade, but the cached `C` palette used by the canvas does not — so we
+// re-run applyPalette whenever the host's theme class flips.
+function watchHostThemeFlip() {
+    const reapply = () => { if (currentTheme === "comfy") applyPalette("comfy"); };
+    const opts = { attributes: true, attributeFilter: ["class"] };
+    new MutationObserver(reapply).observe(document.documentElement, opts);
+    if (document.body) new MutationObserver(reapply).observe(document.body, opts);
 }
 
 function hexToRgb(hex) {
@@ -569,6 +581,7 @@ function createPanel() {
     }
     // always run — primes C from computed CSS so the canvas matches the stylesheet
     applyPalette(currentTheme);
+    watchHostThemeFlip();
     if (saved.modelCollapsed && typeof saved.modelCollapsed === "object") modelCollapsed = saved.modelCollapsed;
     let panelScale = typeof saved.scale === "number" ? saved.scale : 1;
 


### PR DESCRIPTION
## Summary

Adds a new `comfy` theme that, instead of declaring its own colors, inherits ComfyUI's design tokens (`--comfy-menu-bg`, `--input-text`, `--color-gold-500`, etc.) via `var()`. The panel adopts whatever palette the host is in and tracks ComfyUI's light/dark mode flip live through the cascade.

Slots into the existing `[data-aimdo-theme=\"<name>\"]` mechanism added in #4 — no architectural changes.

## What's in the diff

- **`web/aimdo_viz.css`**: one new `[data-aimdo-theme=\"comfy\"]` block mapping `--aimdo-*` to ComfyUI design tokens. Slot colors (`--aimdo-type-*`) are intentionally omitted so LiteGraph hues from `:root` carry through (they're semantic across themes). `--aimdo-fadeOut*` is overridden to neutral mid-tones so the canvas fade reads in both Comfy light and dark modes.
- **`web/aimdo_viz.js`**: adds `\"comfy\"` to `THEME_NAMES` and a small `MutationObserver` (`watchHostThemeFlip`) that re-runs `applyPalette(\"comfy\")` when ComfyUI toggles `.dark-theme` on `<html>`/`<body>`. DOM elements track Comfy's mode change automatically via the CSS cascade; the observer is only needed because the cached `C` palette used by the canvas is plain JS strings.

Total diff: +52 / -1 across two files.

## Test plan

- [ ] Right-click panel → Theme submenu → `Comfy` appears in the list
- [ ] Selecting `Comfy` re-tints panel chrome, graph background, gridlines, bars to match ComfyUI's menu colors
- [ ] Flipping ComfyUI between light and dark mode (Settings → Appearance) re-tints the panel live without reload
- [ ] Switching `Comfy` → other themes → back to `Comfy` works cleanly with no stale state
- [ ] Model-row text and border still show LiteGraph slot hues (purple/red/yellow/etc.) — should be unchanged
- [ ] Behaves identically in docked and floating modes

## Notes

- This does not change the default theme. New installs still get `default`; users can opt into `Comfy` from the menu.
- If a future ComfyUI release renames any of the referenced tokens, the affected `--aimdo-*` will fall back to its `:root` default automatically (no crashes, just a visual mismatch on that token).