### PR TITLE
Fix issue when toggling properties panel hiding the docked bar

### DIFF
--- a/web/aimdo_viz.js
+++ b/web/aimdo_viz.js
@@ -1896,6 +1896,34 @@ function createPanel() {
         applyOffsets();
     }
     attachCanvasObserver();
+
+    // --- Should fix the problem when toggling properties panel causing the docked bar to disappear ---
+    let survivalObserver = null;
+    function startSurvivalObserver() {
+        if (survivalObserver) return;
+        survivalObserver = new MutationObserver(() => {
+            if (!isDocked) return;
+            // Panel is docked but no longer in DOM = actionbar was rebuilt
+            if (!document.getElementById("aimdo-viz-panel")) {
+                const ac = getActionbarContainer();
+                if (!ac) return;
+                // Re-attach: add the docked class, set flex order, append
+                panel.classList.add("aimdo-docked");
+                panel.style.order = dockSide === "left" ? "-1" : "1";
+                ac.appendChild(panel);
+                // Re-apply the section width and ensure body is hidden
+                applyDockSectionWidth();
+                if (!dockExpanded) {
+                    body.style.display = "none";
+                    miniBar.style.display = "block";
+                }
+            }
+        });
+        // Observe body for subtree changes (actionbar creation/destruction)
+        survivalObserver.observe(document.body, { childList: true, subtree: true });
+    }
+    startSurvivalObserver();
+
     body._titleSpan = titleSpan;
     body._miniBar = miniBar;
     body._panel = panel;


### PR DESCRIPTION
Should fix the issue with docked bar disappearing when toggling the properties side panel.

After someone pointing out, i noticed toggling the properties panel makes the bar disappear if docked to top bar.

Before the fix (tested on latest commit cea48ef)
<img width="1545" height="683" alt="before" src="https://github.com/user-attachments/assets/c3e84363-bc80-4432-80ca-b3d184e85621" />

After:
<img width="1545" height="627" alt="after" src="https://github.com/user-attachments/assets/9550c71a-d241-4a14-8bf6-276301213c00" />


Not sure if this is smart way of fixing it, but hopefully:)
PS. torilla tavataan
